### PR TITLE
futexes: wake* take a signed count, not unsigned

### DIFF
--- a/insideout/futexes.nim
+++ b/insideout/futexes.nim
@@ -88,13 +88,13 @@ proc waitMask*[T](monitor: var Atomic[T]; compare: T; mask: uint32;
       result = sysFutex(addr monitor, WaitBitsPrivate, cast[uint32](compare),
                         timeout = addr tm, val3 = mask)
 
-proc wake*[T](monitor: var Atomic[T]; count = high(uint32)): cint {.discardable.} =
+proc wake*[T](monitor: var Atomic[T]; count = high(int32)): cint {.discardable.} =
   ## Wake as many as `count` threads from the same process.
   # Returns the number of actually woken threads
   # or a Posix error code (if negative).
-  result = sysFutex(addr monitor, WakePrivate, count)
+  result = sysFutex(addr monitor, WakePrivate, cast[uint32](count))
 
-proc wakeMask*[T](monitor: var Atomic[T]; mask: uint32; count = high(uint32)): cint {.discardable.} =
+proc wakeMask*[T](monitor: var Atomic[T]; mask: uint32; count = high(int32)): cint {.discardable.} =
   ## Wake as many as `count` threads from the same process,
   ## which are all waiting on any set bit in `mask`.
   # Returns the number of actually woken threads
@@ -105,7 +105,7 @@ proc wakeMask*[T](monitor: var Atomic[T]; mask: uint32; count = high(uint32)): c
     if mask == 0:
       raise FutexError.newException "missing 32-bit mask"
     else:
-      result = sysFutex(addr monitor, WakeBitsPrivate, count, val3 = mask)
+      result = sysFutex(addr monitor, WakeBitsPrivate, cast[uint32](count), val3 = mask)
 
 proc checkWait*(err: cint): cint {.discardable.} =
   if -1 == err:

--- a/insideout/mailboxes.nim
+++ b/insideout/mailboxes.nim
@@ -217,7 +217,7 @@ proc newMailbox*[T](): Mailbox[T] =
   else:
     result = newMailbox[T](high uint32)
 
-proc interrupt*[T](mail: Mailbox[T]; count = high(uint32)) =
+proc interrupt*[T](mail: Mailbox[T]; count = high(int32)) =
   ## interrupt some threads waiting on the mailbox
   assert not mail.isNil
   discard mail[].state.enable Interrupt

--- a/insideout/runtimes.nim
+++ b/insideout/runtimes.nim
@@ -174,7 +174,7 @@ proc thaw*(runtime: Runtime) =
     checkWake wakeMask(runtime[].flags, <<!Frozen)
     interrupt runtime[]
 
-proc poke*(runtime: Runtime; count = high(uint32)) {.deprecated.} =
+proc poke*(runtime: Runtime; count = high(int32)) {.deprecated.} =
   checkWake wake(runtime[].flags, count = count)
 
 proc waitForFlags(runtime: var RuntimeObj; mode: WaitMode; wants: uint32): bool {.raises: [RuntimeError].} =


### PR DESCRIPTION
According to `futex(2)`, `FUTEX_WAKE` and `FUTEX_WAKE_BITSETS` take `INT_MAX` (or `high(cint)` / `high(int32)` in Nim) to wake up all waiters.

Referencing against the kernel sources \[1\], we find that the kernel treat the wakeup count as a **signed** integer, which meant that `high(uint32)` directly translates to `-1`. According to the same source, it seems that at least one thread will be woken up and no errors will arise from passing a value < 1.

This commit change the relevant APIs to take a signed integer instead, properly waking up all waiters by default. This is a breaking change.

\[1\]: https://github.com/torvalds/linux/blob/872cf28b8df9c5c3a1e71a88ee750df7c2513971/kernel/futex/waitwake.c#L155